### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/package-utils.el
+++ b/package-utils.el
@@ -29,6 +29,9 @@
 ;;
 ;;; Code:
 
+(require 'package)
+(require 'async)
+
 (defmacro package-utils-with-packages-list (packages &rest body)
   "Evaluate BODY inside a `package-list-package' buffer.
 


### PR DESCRIPTION
```
In package-utils-installed-packages:
package-utils.el:49:26:Warning: reference to free variable ‘package-alist’

In package-utils-remove-by-name:
package-utils.el:131:37:Warning: reference to free variable ‘package-alist’

In package-utils-install-async:
package-utils.el:141:14:Warning: reference to free variable
    ‘package--initialized’
package-utils.el:151:35:Warning: reference to free variable
    ‘package-archive-contents’

In end of data:
package-utils.el:166:1:Warning: the following functions are not known to be defined:
    package-menu-mode, package-menu--generate,
    package-menu--find-upgrades, package-menu-mark-upgrades,
    package-menu-execute, package-delete, package-installed-p,
    async-start, async-inject-variables
```