### PR TITLE
Add a useful return value to package-utils-list-upgrades

### DIFF
--- a/package-utils.el
+++ b/package-utils.el
@@ -148,14 +148,21 @@ See the second argument to `package-menu--generate'."
 (defun package-utils-list-upgrades (&optional no-fetch)
   "List all packages that can be upgraded.
 
-With prefix argument NO-FETCH, do not call `package-refresh-contents'."
+With prefix argument NO-FETCH, do not call `package-refresh-contents'.
+
+Return true if there were packages to install, nil otherwise."
   (interactive "P")
   (unless no-fetch
     (package-refresh-contents))
   (let ((packages (package-utils-upgradable-packages)))
-    (if (null packages)
-        (message "All packages are already up to date.")
-      (message "Upgradable packages: %s" (mapconcat #'symbol-name packages ", ")))))
+    (cond
+     (packages
+      (message "Upgradable packages: %s"
+               (mapconcat #'symbol-name packages ", "))
+      t)
+     (t
+      (message "All packages are already up to date.")
+      nil))))
 
 ;;;###autoload
 (defun package-utils-upgrade-all (&optional no-fetch)


### PR DESCRIPTION
Return nil from package-utils-list-upgrades when there are no packages to upgrade, otherwise t.

---


Currently it's not possible to know from calling `package-utils-list-upgrades` if there is anything to upgrade. This change makes it possible to show upgrades & only run an upgrade when out of date packages were found.

```
(when (package-utils-list-upgrades)
  (package-utils-upgrade-all-and-recompile :no-fetch))
```

While it's possible to do this already, it relies on more function calls & makes redundant checks for packages to upgrade.

```
(package-refresh-contents)
(package-utils-list-upgrades)
(when (package-utils-upgradable-packages)
   (package-utils-upgrade-all-and-recompile :no-fetch))
```