### PR TITLE
Fix packages being reported multiple times

### DIFF
--- a/package-utils.el
+++ b/package-utils.el
@@ -46,7 +46,8 @@ See the second argument to `package-menu--generate'."
 (defun package-utils-upgradable-packages ()
   "Return the list of upgradable packages as a list of symbols."
   (package-utils-with-packages-list t
-    (mapcar #'car (package-menu--find-upgrades))))
+    ;; Multiple repositories may have the same packages, remove duplicates.
+    (delete-dups (mapcar #'car (package-menu--find-upgrades)))))
 
 (defun package-utils-installed-packages ()
   "Return the list of installed packages as a list of symbols."


### PR DESCRIPTION
Packages to be upgraded found in multiple repositories would be listed multiple times, but only upgraded once.

Resolve using `delete-dups`.

----

The package `transient` was always listed to be upgraded twice,

Example of the output I had:

```
Upgradable packages: company, magit, relint, magit-section, transient, xr, transient
```

In case it helps this is a snippet from my package list:

```
  transient                      0.7.4          built-in              Transient commands
  transient                      20250103.1731  deleted               Transient commands.
```

